### PR TITLE
Explicitly set priority of users.

### DIFF
--- a/lib/Net/Jabber/Bot.pm
+++ b/lib/Net/Jabber/Bot.pm
@@ -786,6 +786,10 @@ sub _jabber_presence_message {
         INFO("Processed unsubscribe request from $from");
         return;
     }
+    
+    # Without explicitly setting a priority, XMPP::Protocol will store all JIDs with an empty
+    # priority under the same key rather than in an array. 
+    $presence->SetPriority(0) unless $presence->GetPriority();
 
     $self->jabber_client->PresenceDBParse($presence); # Since we are always an object just throw it into the db.
 


### PR DESCRIPTION
Without this change, any user without a set priority ($presence->GetPriority() = ''), will override the last when the presencedb is added to. This means that in a groupchat, only users with a defined priority and one user without a priority will exist.
