### PR TITLE
Allow the user to specify the path to the CA cert bundle

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Net-Jabber-Bot
 
+XXX
+Allow the user to specify the path to the CA cert bundle via the 'ssl_ca_path' parameter.
+
 2.1.6
 Spelling errors in documentation
 Display server error message when we think there was a disconnect event.

--- a/lib/Net/Jabber/Bot.pm
+++ b/lib/Net/Jabber/Bot.pm
@@ -34,6 +34,7 @@ has 'server_host'         => (isa => Str, is => 'rw', lazy => 1, default => sub{
 has 'server'              => (isa => Str, is => 'rw');
 has 'port'                => (isa => PosInt, is => 'rw', default => 5222);
 has 'tls'                 => (isa => Bool, is => 'rw', default => '0');
+has 'ssl_ca_path'         => (isa => Str, is => 'rw');
 has 'connection_type'     => (isa => Str, is => 'rw', default => 'tcpip');
 has 'conference_server'   => (isa => Str, is => 'rw');
 has 'username'            => (isa => Str, is => 'rw');
@@ -161,6 +162,7 @@ All options:
         conference_server       => 'conference.host.domain.com',
         server_host             => 'talk.domain.com', # used to specify what jabber server to connect to on connect?
         tls                     => 0,                    # set to 1 for google
+        ssl_ca_path             => '',  # path to your CA cert bundle
         connection_type         => 'tcpip',
         port                    => 522,
         username                => 'username',
@@ -211,6 +213,10 @@ Defaults to 5222
 =item B<tls>
 
 Boolean value. defaults to 0. for google, it is know that this value must be 1 to work.
+
+=item B<ssl_ca_path>
+
+The path to your CA cert bundle. This is passed on to XML::Stream eventually.
 
 =item B<connection_type>
 
@@ -372,6 +378,7 @@ sub _init_jabber {
         hostname => $self->server,
         port => $self->port,
         tls => $self->tls,
+        ssl_ca_path => $self->ssl_ca_path,
         connectiontype => $self->connection_type,
         componentname  => $self->server_host,
     );

--- a/lib/Net/Jabber/Bot.pm
+++ b/lib/Net/Jabber/Bot.pm
@@ -738,6 +738,12 @@ sub _jabber_in_iq_message {
     my $from = $iq->GetFrom();
 #    my $type = $iq->GetType();DEBUG("Type=$type");
     my $query = $iq->GetQuery();#DEBUG("query=" . Dumper($query));
+
+    if (!$query) {
+        DEBUG("iq->GetQuery() returned undef.");
+        return;
+    }
+
     my $xmlns = $query->GetXMLNS();DEBUG("xmlns=$xmlns");
     my $iqReply;
 


### PR DESCRIPTION
This is done by specifying the 'ssl_ca_path' parameter, which is eventually passed down to the XML::Stream constructor.  Without this parameter, you may encounter an error like

```
Invalid or unreadable path specified for ssl_ca_path. at /Library/Perl/5.18/XML/Stream.pm line 639.
```