### PR TITLE
Allow user to disable server certificate validity check

### DIFF
--- a/lib/Net/Jabber/Bot.pm
+++ b/lib/Net/Jabber/Bot.pm
@@ -35,6 +35,7 @@ has 'server'              => (isa => Str, is => 'rw');
 has 'port'                => (isa => PosInt, is => 'rw', default => 5222);
 has 'tls'                 => (isa => Bool, is => 'rw', default => '0');
 has 'ssl_ca_path'         => (isa => Str, is => 'rw');
+has 'ssl_verify'          => (isa => Bool, is => 'rw', default => '1');
 has 'connection_type'     => (isa => Str, is => 'rw', default => 'tcpip');
 has 'conference_server'   => (isa => Str, is => 'rw');
 has 'username'            => (isa => Str, is => 'rw');
@@ -163,6 +164,7 @@ All options:
         server_host             => 'talk.domain.com', # used to specify what jabber server to connect to on connect?
         tls                     => 0,                    # set to 1 for google
         ssl_ca_path             => '',  # path to your CA cert bundle
+        ssl_verify              => 0,   # for testing and for self-signed certificates
         connection_type         => 'tcpip',
         port                    => 522,
         username                => 'username',
@@ -217,6 +219,10 @@ Boolean value. defaults to 0. for google, it is know that this value must be 1 t
 =item B<ssl_ca_path>
 
 The path to your CA cert bundle. This is passed on to XML::Stream eventually.
+
+=item B<ssl_verify>
+
+Enable or disable server certificate validity check when connecting to server. This is passed on to XML::Stream eventually.
 
 =item B<connection_type>
 
@@ -379,6 +385,7 @@ sub _init_jabber {
         port => $self->port,
         tls => $self->tls,
         ssl_ca_path => $self->ssl_ca_path,
+        ssl_verify => $self->ssl_verify,
         connectiontype => $self->connection_type,
         componentname  => $self->server_host,
     );


### PR DESCRIPTION
* Allow user to disable ssl validity check for server' cert during ssl
  handshake. This is useful for connecting to servers with self-signed
  certificates, for example to localhost (for testing) or to corporate
  servers in internal network.