### PR TITLE
Allow outgoing multiline messages

### DIFF
--- a/lib/Net/Jabber/Bot.pm
+++ b/lib/Net/Jabber/Bot.pm
@@ -1018,7 +1018,7 @@ sub _send_individual_message {
 
     # Strip out anything that's not a printable character except new line, we want to be able to send multiline message, aren't we?
     # Now with unicode support?
-    $message_chunk =~ s/[^[\n|\r|\r\n|:print:]]+/./xmsg;
+    $message_chunk =~ s/[^[\n|\r|\r\n|[:print:]]]+/./xmsg;
 
     my $message_length = length($message_chunk);
     DEBUG("Sending message $yday-$hour-$messages_this_hour $message_length bytes to $recipient");

--- a/lib/Net/Jabber/Bot.pm
+++ b/lib/Net/Jabber/Bot.pm
@@ -1018,7 +1018,7 @@ sub _send_individual_message {
 
     # Strip out anything that's not a printable character except new line, we want to be able to send multiline message, aren't we?
     # Now with unicode support?
-    $message_chunk =~ s/[^[\n|\r|\r\n|[:print:]]]+/./xmsg;
+    $message_chunk =~ s/[^\r\n[:print:]]+/./xmsg;
 
     my $message_length = length($message_chunk);
     DEBUG("Sending message $yday-$hour-$messages_this_hour $message_length bytes to $recipient");

--- a/lib/Net/Jabber/Bot.pm
+++ b/lib/Net/Jabber/Bot.pm
@@ -1016,9 +1016,9 @@ sub _send_individual_message {
         return "Server is down.\n";
     }
 
-    # Strip out anything that's not a printable character
+    # Strip out anything that's not a printable character except new line, we want to be able to send multiline message, aren't we?
     # Now with unicode support?
-    $message_chunk =~ s/[^[:print:]]+/./xmsg; 
+    $message_chunk =~ s/[^[\n|\r|\r\n|:print:]]+/./xmsg;
 
     my $message_length = length($message_chunk);
     DEBUG("Sending message $yday-$hour-$messages_this_hour $message_length bytes to $recipient");


### PR DESCRIPTION
Regex `r/^[:print:]/./msg` is too restrictive, it strips also newline, but for some reasons it can be useful to send multiline messages, especially on rate-limited servers.